### PR TITLE
Make naming more coherent + install a configuration file for LIPMWalking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,13 @@ message("-- TALOS_URDF_PATH: ${MC_RTC_TALOS_URDF_PATH}")
 
 configure_file(src/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/config.h")
 
+# Generate robot module
 add_robot(talos src/talos.cpp src/talos.h)
 target_include_directories(talos PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/include")
+
+# Install LIPMWalking file for talos.
+install(FILES etc/mc_controllers/LIPMWalking/talos.yaml
+  DESTINATION ${MC_CONTROLLER_RUNTIME_INSTALL_PREFIX}/LIPMWalking/)
 
 option(DISABLE_TESTS "Disable unit tests" OFF)
 if(NOT ${DISABLE_TESTS})

--- a/etc/mc_controllers/LIPMWalking/talos.yaml
+++ b/etc/mc_controllers/LIPMWalking/talos.yaml
@@ -1,0 +1,326 @@
+initial_plan: custom_forward
+# for the external planner HybridPlanner
+HybridPlanner:
+  Tp: 6
+  delta: 0.05
+  Ts_limit: [1,2]
+  kinematics_cstr: [0.35,0.08]
+  feet_distance: 0.17
+  offset_angle_deg: 2
+  mean_speed: 0.1
+  robot_height: 150
+  max_rotation: 0.17
+mpc:
+  weights:
+    jerk: 1.0
+    vel: [10.0, 100.0]
+    zmp: 1000.0
+tasks:
+  posture:
+    stiffness: 1.0
+    weight: 10.0
+robot_models:
+  talos:
+    sole:
+      half_length: 0.11
+      half_width: 0.05
+      friction: 0.7
+    torso:
+      pitch: 0.0
+plans:
+  talos:
+    ashibumi: # stepping in place
+      double_support_duration: 0.2
+      single_support_duration: 0.8
+      swing_height: 0.04
+      contacts:
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+    comanoid_airbus_staircase:
+      com_height: 0.84
+      init_dsp_duration: 0.6
+      single_support_duration: 1.4
+      double_support_duration: 0.2
+      final_dsp_duration: 0.6
+      swing_height: 0.24
+      landing_duration: 0.1
+      takeoff_duration: 0.42
+      torso_pitch: 0.2
+      contacts:
+        - pose:
+            translation: [-0.02, 0.105, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [-0.02, -0.105, 0.0]
+          surface: RightFootCenter
+          swing:
+            takeoff_offset: [-0.03, 0.0, 0.0]
+            takeoff_pitch: 0.6
+        - pose:
+            translation: [0.24, 0.105, 0.185]
+          surface: LeftFootCenter
+          swing:
+            takeoff_offset: [-0.02, 0.0, 0.0]
+        - pose:
+            translation: [0.24, -0.105, 0.185]
+          surface: RightFootCenter
+          swing:
+            takeoff_offset: [-0.03, 0.0, 0.0]
+            takeoff_pitch: 0.6
+        - pose:
+            translation: [0.48, 0.105, 0.37]
+          surface: LeftFootCenter
+          swing:
+            takeoff_offset: [-0.02, 0.0, 0.0]
+        - pose:
+            translation: [0.48, -0.105, 0.37]
+          surface: RightFootCenter
+          swing:
+            takeoff_offset: [-0.03, 0.0, 0.0]
+            takeoff_pitch: 0.6
+        - pose:
+            translation: [0.74, 0.105, 0.555]
+          surface: LeftFootCenter
+          swing:
+            takeoff_offset: [-0.02, 0.0, 0.0]
+        - pose:
+            translation: [0.74, -0.105, 0.555]
+          surface: RightFootCenter
+          swing:
+            takeoff_offset: [-0.03, 0.0, 0.0]
+            takeoff_pitch: 0.6
+        - pose:
+            translation: [1.0, 0.105, 0.74]
+          surface: LeftFootCenter
+          swing:
+            height: 0.2
+            takeoff_offset: [-0.02, 0.0, 0.0]
+        - pose:
+            translation: [1.0, -0.105, 0.74]
+          surface: RightFootCenter
+          swing:
+            height: 0.2
+            takeoff_offset: [-0.03, 0.0, 0.0]
+            takeoff_pitch: 0.6
+        - pose:
+            translation: [1.25, 0.105, 0.885]
+          surface: LeftFootCenter
+        - pose:
+            translation: [1.25, -0.105, 0.885]
+          surface: RightFootCenter
+      mpc:
+        weights:
+          jerk: 1.0
+          vel: [10.0, 300.0]
+          zmp: 1000.0
+    custom_backward:
+      double_support_duration: 0.2
+      single_support_duration: 0.8
+      step_length: 0.15
+      swing_height: 0.05
+      contacts:
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+    custom_forward:
+      double_support_duration: 0.1
+      single_support_duration: 0.7
+      step_length: 0.2
+      swing_height: 0.04
+      contacts:
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+    custom_lateral:
+      double_support_duration: 0.2
+      single_support_duration: 0.8
+      step_length: 0.1
+      swing_height: 0.04
+      contacts:
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          surface: LeftFootCenter
+      mpc:
+        weights:
+          jerk: 1.0
+          vel: [10.0, 300.0]
+          zmp: 1000.0
+    walk_backward_75cm:
+      double_support_duration: 0.2
+      single_support_duration: 0.8
+      swing_height: 0.05
+      contacts:
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          ref_vel: [0.0, 0.0, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          ref_vel: [0.0, 0.0, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [-0.15, -0.105, 0.0]
+          ref_vel: [-0.075, 0.0, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [-0.3, 0.105, 0.0]
+          ref_vel: [-0.15, 0.0, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [-0.45, -0.105, 0.0]
+          ref_vel: [-0.15, 0.0, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [-0.6, 0.105, 0.0]
+          ref_vel: [-0.075, 0.0, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [-0.75, -0.105, 0.0]
+          ref_vel: [0.0, 0.0, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [-0.75, 0.105, 0.0]
+          ref_vel: [0.0, 0.0, 0.0]
+          surface: LeftFootCenter
+    walk_forward_100cm:
+      double_support_duration: 0.1
+      single_support_duration: 0.7
+      swing_height: 0.04
+      contacts:
+        - pose:
+            translation: [0.0, -0.105, 0.0]
+          ref_vel: [0.0, 0.0, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.0, 0.105, 0.0]
+          ref_vel: [0.0, 0.0, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [0.2, -0.105, 0.0]
+          ref_vel: [0.12, 0.0, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.4, 0.105, 0.0]
+          ref_vel: [0.25, 0.0, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [0.6, -0.105, 0.0]
+          ref_vel: [0.25, 0.0, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.8, 0.105, 0.0]
+          ref_vel: [0.12, 0.0, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [1.0, -0.105, 0.0]
+          ref_vel: [0.0, 0.0, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [1.0, 0.105, 0.0]
+          ref_vel: [0.0, 0.0, 0.0]
+          surface: LeftFootCenter
+    warmup:
+      double_support_duration: 0.1
+      single_support_duration: 0.7
+      swing_height: 0.04
+      contacts:
+        - pose:
+            translation: [0.035, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.035, 0.105, 0.0]
+          surface: LeftFootCenter
+        - pose:
+            translation: [0.035, -0.105, 0.0]
+          surface: RightFootCenter
+        - pose:
+            translation: [0.035, 0.105, 0.0]
+          surface: LeftFootCenter
+constraints:
+  - type: contact
+  # KinematicsConstraint, i.e. joint limits see equation (3.6) in Joris Vaillant's thesis
+  #  interaction distance (d_i) safety distance (d_s) damper offset (xi_off)
+  #  applies to main robot
+  - type: kinematics
+    damper: [0.1, 0.01, 0.5]
+collisions:
+  - type: collision
+    useMinimal: true
+contacts: []
+robots:
+  ground:
+    module: env/ground
+
+# Finite state machine
+#
+StatesFiles:
+- "/home/vscode/workspace/install/lib/mc_controller/fsm/states/data"
+- "/home/vscode/workspace/install/lib/mc_controller/lipm_walking_controller/states/data"
+StatesLibraries:
+- "/home/vscode/workspace/install/lib/mc_controller/fsm/states"
+- "/home/vscode/workspace/install/lib/mc_controller/lipm_walking_controller/states"
+Managed: false
+StepByStep: false
+init: LIPMWalking::Initial
+transitions:
+  - [LIPMWalking::Initial, Standing, LIPMWalking::WalkFSM]
+
+Plugins: [footsteps_planner_plugin]
+
+# Set realRobot's joint configuration from encoder readings
+ObserverPipelines:
+  name: "LIPMWalkingObserverPipeline"
+  gui: true
+  observers:
+    - type: Encoder
+    - type: Attitude
+      required: false
+    - type: KinematicInertial
+      config:
+        anchorFrame:
+          maxAnchorFrameDiscontinuity: 0.02
+    - type: BodySensor
+      update: false

--- a/src/talos.h
+++ b/src/talos.h
@@ -47,7 +47,7 @@ extern "C"
 {
   ROBOT_MODULE_API void MC_RTC_ROBOT_MODULE(std::vector<std::string> & names)
   {
-    names = {"Talos"};
+    names = {"talos"};
   }
   ROBOT_MODULE_API void destroy(mc_rbdyn::RobotModule * ptr)
   {
@@ -55,12 +55,12 @@ extern "C"
   }
   ROBOT_MODULE_API mc_rbdyn::RobotModule * create(const std::string & n)
   {
-    ROBOT_MODULE_CHECK_VERSION("Talos")
-    if(n == "Talos")
+    ROBOT_MODULE_CHECK_VERSION("talos")
+    if(n == "talos")
     {
       return new mc_robots::TalosRobotModule(false);
     }
-    if(n == "TalosFixed")
+    if(n == "talosFixed")
     {
       return new mc_robots::TalosRobotModule(false);
     }


### PR DESCRIPTION
The first commit address the problem that robot's name is "Talos", while in another place it is using a small "t" because the library's module is ```talos.so```. So we changed the name to a small "t"alos.

The second commit provides a file ```etc/mc_controllers/LIPMWalking/talos.yaml``` to avoid interfering with the LIPMWalking controller initial yaml file as suggested nicely by @arntanguy in https://github.com/jrl-umi3218/lipm_walking_controller/pull/55#issuecomment-3108336919